### PR TITLE
FarServiceUniqueName seems to be ignored fix

### DIFF
--- a/SqlTableDependency.Extensions/ChangeLog.md
+++ b/SqlTableDependency.Extensions/ChangeLog.md
@@ -1,5 +1,8 @@
 ﻿# SqlTableDependency.Extensions
 
+### 3.2.0
+- fixes FarServiceUniqueName seems to be ignored #23 by @AlexisPicot 
+
 ### 3.1.0
 - SqlTableDependencyEx - extracted fixes for SqlTableDependency
 - `SqlTableDependencySettings<TEntity>` FarServiceUniqueName

--- a/SqlTableDependency.Extensions/SqlTableDependency.Extensions.csproj
+++ b/SqlTableDependency.Extensions/SqlTableDependency.Extensions.csproj
@@ -11,9 +11,9 @@
     <PackageTags>SQL Server, SQL table dependency notifications,connection recovery, CQRS, MSSQL Service Broker, Event sourcing</PackageTags>
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <Copyright>@tomasfabian</Copyright>
-    <Version>3.1.0</Version>
+    <Version>3.2.0-rc.1</Version>
     <PackageReleaseNotes>https://github.com/tomasfabian/Joker/blob/master/SqlTableDependency.Extensions/ChangeLog.md</PackageReleaseNotes>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
+    <AssemblyVersion>3.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <Import Project="..\NugetProjects\System.Reactive.csprojimport" />

--- a/SqlTableDependency.Extensions/SqlTableDependencyProvider.cs
+++ b/SqlTableDependency.Extensions/SqlTableDependencyProvider.cs
@@ -279,10 +279,7 @@ namespace SqlTableDependency.Extensions
             schemaName: SchemaName, mapper: modelToTableMapper, updateOf: sqlTableDependencySettings.UpdateOf,
             filter: sqlTableDependencySettings.Filter, notifyOn: sqlTableDependencySettings.NotifyOn,
             executeUserPermissionCheck: sqlTableDependencySettings.ExecuteUserPermissionCheck,
-            includeOldValues: sqlTableDependencySettings.IncludeOldValues)
-                 {
-                   Settings = Settings
-                 };
+            includeOldValues: sqlTableDependencySettings.IncludeOldValues, Settings);
 
         default:
           return null;

--- a/SqlTableDependency.Extensions/SqlTableDependencyWithReconnection.cs
+++ b/SqlTableDependency.Extensions/SqlTableDependencyWithReconnection.cs
@@ -50,9 +50,15 @@ namespace SqlTableDependency.Extensions
   {
     #region Constructors
 
-    public SqlTableDependencyWithReconnection(string connectionString, string tableName = null, string schemaName = null, IModelToTableMapper<TEntity> mapper = null, IUpdateOfModel<TEntity> updateOf = null, ITableDependencyFilter filter = null, DmlTriggerType notifyOn = DmlTriggerType.All, bool executeUserPermissionCheck = true, bool includeOldValues = false)
+    public SqlTableDependencyWithReconnection(string connectionString, string tableName = null, string schemaName = null, 
+      IModelToTableMapper<TEntity> mapper = null, IUpdateOfModel<TEntity> updateOf = null, ITableDependencyFilter filter = null, 
+      DmlTriggerType notifyOn = DmlTriggerType.All, bool executeUserPermissionCheck = true, bool includeOldValues = false, 
+      SqlTableDependencySettings<TEntity> settings = null)
       : base(connectionString, tableName, schemaName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck, includeOldValues)
     {
+      Settings = settings;
+
+      _dataBaseObjectsNamingConvention = GetBaseObjectsNamingConvention();
     }
 
     #endregion

--- a/SqlTableDependency.Extensions/SqlTableDependencyWithUniqueScope.cs
+++ b/SqlTableDependency.Extensions/SqlTableDependencyWithUniqueScope.cs
@@ -9,9 +9,11 @@ namespace SqlTableDependency.Extensions
   {
     #region Constructors
 
-    public SqlTableDependencyWithUniqueScope(string connectionString, string tableName = null, string schemaName = null, IModelToTableMapper<TEntity> mapper = null, IUpdateOfModel<TEntity> updateOf = null, ITableDependencyFilter filter = null, DmlTriggerType notifyOn = DmlTriggerType.All, bool executeUserPermissionCheck = true, bool includeOldValues = false)
-      : base(connectionString, tableName, schemaName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck,
-        includeOldValues)
+    public SqlTableDependencyWithUniqueScope(string connectionString, string tableName = null, string schemaName = null,
+      IModelToTableMapper<TEntity> mapper = null, IUpdateOfModel<TEntity> updateOf = null, ITableDependencyFilter filter = null,
+      DmlTriggerType notifyOn = DmlTriggerType.All, bool executeUserPermissionCheck = true, bool includeOldValues = false,
+      SqlTableDependencySettings<TEntity> sqlTableDependency = null)
+      : base(connectionString, tableName, schemaName, mapper, updateOf, filter, notifyOn, executeUserPermissionCheck, includeOldValues, sqlTableDependency)
     {
     }
 


### PR DESCRIPTION
This PR fixes #23 the issue with the virtual member call `GetBaseObjectsNamingConvention` in a base constructor of `SqlTableDependencyWithReconnection`, which stems from the `TableDependency.SqlClient` assembly.